### PR TITLE
Send the results to the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints*
+__pycache__*

--- a/dja_match.py
+++ b/dja_match.py
@@ -34,6 +34,7 @@ def spec_tab_from_db():
     spec_tab = db.SQL("""
                 SELECT ne.root, ne.file, ne.ra, ne.dec
                 FROM nirspec_extractions ne
+                WHERE ne.ra > 0.0.001
                 """)
     return(spec_tab)
 
@@ -62,6 +63,7 @@ def unmatched_spec_from_db():
                 WHERE ne.file NOT IN (SELECT DISTINCT nrp.file_spec
                                         FROM nirspec_phot_match nrp
                                         )
+                AND ne.ra > 0.001
                 """)
     return(spec_tab)
 
@@ -116,7 +118,7 @@ path_to_outfile='cats/'
 
     Returns
     -------
-    empty
+    marriedcat_concat : joined catalog, format=astropy Table
     """
 
     photcat_list = np.unique(photcat_concat['file_phot'])
@@ -149,9 +151,10 @@ path_to_outfile='cats/'
         elif i>0:
             marriedcat_concat = vstack([marriedcat_concat,married_tab])
 
-    marriedcat_concat.write(path_to_outfile+outfile_name+'.fits', format='fits', overwrite=True)
+    if outfile_name is not None:
+        marriedcat_concat.write(path_to_outfile+outfile_name+'.fits', format='fits', overwrite=True)
 
-    return()
+    return(marriedcat_concat)
 
 
     
@@ -178,7 +181,7 @@ path_to_outfile='cats/'
 
     Returns
     -------
-    empty
+    photcat_concat : concatenated photometry table
     """
 
     for i in range(len(photcat_list)):
@@ -198,9 +201,10 @@ path_to_outfile='cats/'
         elif i>0:
             photcat_concat = vstack([photcat_concat,photcat_sub])
     
-    photcat_concat.write(path_to_outfile+outfile_name+'.fits',format='fits', overwrite=True)
+    if outfile_name is not None:
+        photcat_concat.write(path_to_outfile+outfile_name+'.fits',format='fits', overwrite=True)
 
-    return()
+    return(photcat_concat)
 
 
 # --------------------------------------------------------------
@@ -226,7 +230,7 @@ path_to_outfile='cats/'
     
     Returns
     -------
-    empty    
+    phot_zout_match_concat : matched table, format=astropy Table    
     """
 
     for i in range(len(photcat_list)):
@@ -282,7 +286,8 @@ path_to_outfile='cats/'
         else:
             print('Check index in for loop!')
 
-    phot_zout_match_concat.write(path_to_outfile+outfile_name+'.fits', format='fits', overwrite=True)
+    if outfile_name is not None:
+        phot_zout_match_concat.write(path_to_outfile+outfile_name+'.fits', format='fits', overwrite=True)
     
-    return()
+    return(phot_zout_match_concat)
 

--- a/dja_spect_phot_match.ipynb
+++ b/dja_spect_phot_match.ipynb
@@ -18,7 +18,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Set ROOT_PATH=/Users/rashmig/Desktop/DAWN/DJA/code/dja_match_github\n"
+      "Set ROOT_PATH=/usr/local/share/python/dawn-dja-match\n"
      ]
     }
    ],
@@ -46,11 +46,106 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "c618a66c-280c-4c88-828c-2fb4a71a7fc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove cosmos-transients-v3 from nirspec_phot_match so that the script has something to do while testing\n",
+    "if (1):\n",
+    "    db.execute(\"\"\"delete from nirspec_phot_match where root_spec = 'cosmos-transients-v3'\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "6ae12f84-e3a6-420d-a892-a5cb8865c444",
    "metadata": {},
    "outputs": [],
    "source": [
     "ne_tab = dm.unmatched_spec_from_db()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "72d9d410-23ea-4e7f-95b6-b145a8a5d222",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N=2980 unmatched spectra\n",
+      "   N  value     \n",
+      "====  ==========\n",
+      "   1  glazebrook-cos-obs3-v2\n",
+      "   2  macsj0647-hr-v2\n",
+      "   5  rubies-uds1-v2\n",
+      "   5  ceers-ddt-v1\n",
+      "   7  glazebrook-v1\n",
+      "   7  glazebrook-v2\n",
+      "  12  rubies-egs61-v2\n",
+      "  12  ceers-ddt-v2\n",
+      "  13  rubies-egs1-v2\n",
+      "  18  macsj0647-v2\n",
+      "  18  macsj0647-v1\n",
+      "  20  smacs0723-ero-v2\n",
+      "  20  smacs0723-ero-v1\n",
+      "  21  macsj0647-single-v1\n",
+      "  23  macs1423-v1\n",
+      "  23  macs1423-v2\n",
+      "  25  abell370-v2\n",
+      "  26  abell370-v1\n",
+      "  27  macs0417-v1\n",
+      "  27  macs0417-v2\n",
+      "  27  macs0416-v2\n",
+      "  28  macs0416-v1\n",
+      "  29  rxj2129-ddt-v1\n",
+      "  30  borg-2203p1851-v1\n",
+      "  32  snh0pe-v2 \n",
+      "  33  borg-2203p1851-v2\n",
+      "  34  macs1149-v2\n",
+      "  35  borg-0859p4114-v1\n",
+      "  36  snH0pe-v1 \n",
+      "  38  borg-1033p5051-v1\n",
+      "  39  borg-1033p5051-v2\n",
+      "  40  borg-0859p4114-v2\n",
+      "  43  borg-1437p5044-v2\n",
+      "  45  suspense-kriek-v2\n",
+      "  45  borg-0314m6712-v1\n",
+      "  46  jades-gds-wide-lr-v1\n",
+      "  46  borg-1437p5044-v1\n",
+      "  50  borg-0314m6712-v2\n",
+      "  77  rxj2129-ddt-v2\n",
+      "  86  cecilia-v1\n",
+      "  86  cecilia-v2\n",
+      "  90  stark-a1703-v2\n",
+      "  96  jades-gds-wide-mr-v1\n",
+      " 112  whl0137-v1\n",
+      " 124  cosmos-alpha-v3\n",
+      " 128  spt0615-v1\n",
+      " 138  jades-gds-wide-v2\n",
+      " 210  pearls-transients-v2\n",
+      " 215  pearls-transients-v1\n",
+      " 306  cosmos-transients-v3\n",
+      " 324  suspense-kriek-v1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<grizli.utils.Unique at 0x13aa7a8c0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(f'N={len(ne_tab)} unmatched spectra')\n",
+    "# Summarize missing data by root\n",
+    "utils.Unique(ne_tab['root'])"
    ]
   },
   {
@@ -63,12 +158,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "687611b8-3395-46ff-ab04-aa82f15b12da",
    "metadata": {},
    "outputs": [],
    "source": [
     "gr_tab = dm.grizli_phot_from_db()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c858be4f-bafa-4f31-909c-452dc84be5a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N=1159719 rows from grizli_photometry\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'N={len(gr_tab)} rows from grizli_photometry')"
    ]
   },
   {
@@ -81,16 +194,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "57c25a58-6701-4591-b887-d298b30d464f",
    "metadata": {},
    "outputs": [],
    "source": [
     "# saves outfile matched catalogue to 'cats' folder\n",
-    "\n",
     "matched_tab = dm.match_spec_phot_cats(photcat_concat=gr_tab,\n",
     "                                      spec_tab=ne_tab,\n",
-    "                                      outfile_name='spec_phot_match_tab')"
+    "                                      sep=30, # Match separation\n",
+    "                                      outfile_name=None) #'spec_phot_match_tab'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1c7106b7-377b-4508-82e6-e824cf20f8f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 365 new matches\n"
+     ]
+    }
+   ],
+   "source": [
+    "has_match = matched_tab['dr'] < 0.25\n",
+    "print(f'Found {has_match.sum()} new matches')"
    ]
   },
   {
@@ -98,26 +230,188 @@
    "id": "7a03c1fc-2d7a-469b-9e1c-7957e4f9e9bf",
    "metadata": {},
    "source": [
-    "#### read output matched table"
+    "#### read output matched table \n",
+    "\n",
+    "(not used since the function above now just returns the table rather than writing to a file)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "38b215d9-2a6f-460a-873c-5488cb7412fb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "matched_tab_read = utils.read_catalog('cats/spec_phot_match_tab.fits')"
+    "# if matched_tab is None:\n",
+    "#     matched_tab_read = utils.read_catalog('cats/spec_phot_match_tab.fits')\n",
+    "# else:\n",
+    "#     matched_tab_read = matched_tab"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81fb31dd-5eec-4bb5-a397-86d908207630",
+   "metadata": {},
+   "source": [
+    "## Prepare the table for sending to the database"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "056b0703-8917-4acb-95f7-05a9861c8334",
+   "execution_count": 10,
+   "id": "b6529b22-0277-43ce-aa57-84e24c876bfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Set string column:  root_spec\n",
+      "Set string column:  file_spec\n",
+      "Set string column:  file_phot\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rename root > root_spec to avoid conflict with existing tables\n",
+    "if 'root' in matched_tab.colnames:\n",
+    "    matched_tab.rename_column('root', 'root_spec')\n",
+    "\n",
+    "# Make sure columns are strings not bytes\n",
+    "for c in matched_tab.colnames:\n",
+    "    if isinstance(matched_tab[c][0], str):\n",
+    "        print('Set string column: ', c)\n",
+    "        matched_tab[c] = [str(r) for r in matched_tab[c]]\n",
+    "\n",
+    "matched_tab['file_phot'] = [f.replace('phot_apcorr','phot') for f in matched_tab['file_phot']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0ee06267-1232-4d0c-8224-817e976e805a",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Photometric catalogs already done\n",
+    "done = db.SQL(\"\"\"select file_phot, count(file_phot) from nirspec_phot_match\n",
+    "group by file_phot\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "109084a6-4392-4b6d-b47d-8a63b3ac2130",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   N  value     \n",
+      "====  ==========\n",
+      " 247  primer-cosmos-west-grizli-v7.0-fix_phot.fits\n",
+      " 249  primer-cosmos-east-grizli-v7.0-fix_phot.fits\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Photometric catalogs in matches\n",
+    "un = utils.Unique(matched_tab['file_phot'], verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ad012dae-1774-48c5-b65c-c8f738c241ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             field   new  done new=done\n",
+      "      primer-cosmos-east-grizli-v7.0-fix_phot.fits   249   804  False\n",
+      "      primer-cosmos-west-grizli-v7.0-fix_phot.fits   247  1646  False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'field':>50} {'new':>5} {'done':>5} {'new=done'}\")\n",
+    "\n",
+    "for v in un.values:\n",
+    "    if v in done['file_phot']:\n",
+    "        ix = done['file_phot'] == v\n",
+    "        nd = done['count'][ix][0]\n",
+    "        print(f\"{v:>50} {un[v].sum():>5} {nd:>5}  {un[v].sum() == nd}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "59d60720-4f58-4eab-b4ce-b24e1494b4d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New fields: \n",
+      "-----------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "prev = np.isin(un.values, done['file_phot'])\n",
+    "print('New fields: \\n-----------\\n' + '\\n'.join(np.array(un.values)[~prev].tolist()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "7291848e-bcd6-4a7e-84b7-bdd7ce063780",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Add   249 rows (   0 in matched_tab,  804 in table)) to nirspec_phot_match for file_phot = 'primer-cosmos-east-grizli-v7.0-fix_phot.fits'\n",
+      "Add   247 rows (   0 in matched_tab, 1646 in table)) to nirspec_phot_match for file_phot = 'primer-cosmos-west-grizli-v7.0-fix_phot.fits'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Send rows grouped by file_phot\n",
+    "un = utils.Unique(matched_tab['file_phot'], verbose=False)\n",
+    "\n",
+    "# Just test when False\n",
+    "SEND_TO_DB = True\n",
+    "\n",
+    "for v in un.values:\n",
+    "\n",
+    "    old = db.SQL(f\"\"\"select file_phot, file_spec from nirspec_phot_match where file_phot = '{v}'\"\"\")\n",
+    "    old_count = db.SQL(f\"\"\"select count(file_phot) from nirspec_phot_match where file_phot = '{v}'\"\"\")['count'][0]\n",
+    "\n",
+    "    new = un[v] & (~np.isin(matched_tab['file_spec'], old['file_spec']))\n",
+    "    old = un[v] & (np.isin(matched_tab['file_spec'], old['file_spec']))\n",
+    "\n",
+    "    print(f\"Add {new.sum():>5} rows ({old.sum():>4} in matched_tab, {old_count:>4} in table)) to nirspec_phot_match for file_phot = '{v}'\")\n",
+    "\n",
+    "    # Now send the subset of rows\n",
+    "    if (old.sum() == old_count):\n",
+    "        # Replace all rows\n",
+    "        print(f'    Replace N={un[v].sum()}')\n",
+    "        if SEND_TO_DB:\n",
+    "            db.execute(f\"\"\"delete from nirspec_phot_match where file_phot = '{v}'\"\"\")\n",
+    "            db.send_to_database('nirspec_phot_match', matched_tab[un[v]], if_exists='append')\n",
+    "\n",
+    "    elif (new.sum() > 0):\n",
+    "        # Just send new rows\n",
+    "        if SEND_TO_DB:\n",
+    "            db.send_to_database('nirspec_phot_match', matched_tab[new], if_exists='append')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Works great! 

I added a few things:

1. Only query extractions that have `ra > 0`.  Some background slits don't have the coordinates populated correctly so they'll never match
2. Add option to just return the tables from the script functions rather than writing them to files
3. Add sending the resulting match table to the database at the end